### PR TITLE
Add image count option for Google provider

### DIFF
--- a/example.py
+++ b/example.py
@@ -30,6 +30,15 @@ async def main() -> None:
                 index=0
             )
             selected_model = selected_model_enum.value
+
+            # Allow selecting the number of images to generate
+            num_images = st.number_input(
+                "Number of Images",
+                min_value=1,
+                max_value=4,
+                value=1,
+                step=1,
+            )
         elif provider == Provider.STABILITYAI:
             model_options = list(StabilityModel)
             selected_model_enum = st.selectbox(
@@ -181,6 +190,8 @@ async def main() -> None:
                 
                 # Prepare kwargs based on provider
                 kwargs = {}
+                if provider == Provider.GOOGLE:
+                    kwargs["n"] = num_images
                 if provider == Provider.OPENAI and selected_model == OpenAIModel.DALL_E_3.value:
                     kwargs["size"] = size
                     kwargs["quality"] = quality

--- a/src/celeste_image_generation/providers/google.py
+++ b/src/celeste_image_generation/providers/google.py
@@ -15,9 +15,29 @@ class GoogleImageGenerator(BaseImageGenerator):
         self.model_name = model
 
     async def generate_image(self, prompt: ImagePrompt, **kwargs: Any) -> List[GeneratedImage]:
+        """Generate images using Google's Imagen models."""
+
+        # Allow users to request multiple images via common parameter names
+        num_images = (
+            kwargs.get("n")
+            or kwargs.get("num_images")
+            or kwargs.get("number_of_images")
+        )
+
+        config = None
+        if num_images is not None:
+            try:
+                num_images = int(num_images)
+            except (TypeError, ValueError):
+                raise ValueError("num_images must be an integer")
+
+            # Build the generation config with desired number of images
+            config = genai.types.GenerateImagesConfig(number_of_images=num_images)
+
         response = await self.client.aio.models.generate_images(
             model=self.model_name,
             prompt=prompt.content,
+            config=config,
         )
         
         return [


### PR DESCRIPTION
## Summary
- support specifying number of images for Google Imagen models
- expose the new option in `example.py` Streamlit app

## Testing
- `python -m py_compile src/celeste_image_generation/providers/google.py example.py`

------
https://chatgpt.com/codex/tasks/task_e_688cca86ec18832c9f24ee789a3f6654