### PR TITLE
Remove unused Optional/time imports

### DIFF
--- a/src/celeste_image_generation/providers/huggingface.py
+++ b/src/celeste_image_generation/providers/huggingface.py
@@ -1,6 +1,6 @@
 import base64
 import io
-from typing import Any, List, Optional
+from typing import Any, List
 import aiohttp
 from PIL import Image
 

--- a/src/celeste_image_generation/providers/luma.py
+++ b/src/celeste_image_generation/providers/luma.py
@@ -1,6 +1,5 @@
 import asyncio
-import time
-from typing import Any, List, Optional
+from typing import Any, List
 import aiohttp
 
 from celeste_image_generation.base import BaseImageGenerator

--- a/src/celeste_image_generation/providers/openai.py
+++ b/src/celeste_image_generation/providers/openai.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List
 import base64
 import aiohttp
 


### PR DESCRIPTION
## Summary
- drop `Optional` from typing imports in OpenAI and HuggingFace providers
- remove unused `time` and `Optional` imports from Luma provider

## Testing
- `pytest -q`
- `python -m py_compile src/celeste_image_generation/providers/openai.py src/celeste_image_generation/providers/huggingface.py src/celeste_image_generation/providers/luma.py`


------
https://chatgpt.com/codex/tasks/task_e_6891f41b1a44832caf644b426b8fd225