### PR TITLE
chore: add .claude directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ output/
 outputs/
 temp/
 tmp/
+
+# Claude AI
+.claude/


### PR DESCRIPTION
## Summary
- Added `.claude/` directory to gitignore to exclude Claude AI configuration files from version control

## Test plan
- [x] Verified .gitignore properly excludes .claude directory
- [x] Pre-commit hooks pass

Generated with Claude Code