### PR TITLE
refactor: make provider validation non-raising

### DIFF
--- a/src/celeste_image_generation/__init__.py
+++ b/src/celeste_image_generation/__init__.py
@@ -57,11 +57,7 @@ def create_image_generator(
         provider_enum not in SUPPORTED_PROVIDERS
         or provider_enum not in provider_mapping
     ):
-        supported = [p.value for p in provider_mapping.keys()]
-        raise ValueError(
-            f"Unsupported provider: {provider_enum.value}. "
-            f"Supported providers: {supported}"
-        )
+        raise ValueError(f"Unsupported or unmapped provider: {provider_enum}")
 
     # Validate environment for the chosen provider
     settings.validate_for_provider(provider_enum.value)

--- a/src/celeste_image_generation/providers/google.py
+++ b/src/celeste_image_generation/providers/google.py
@@ -15,10 +15,10 @@ class GoogleImageGenerator(BaseImageGenerator):
         super().__init__(**kwargs)
         self.client = genai.Client(api_key=settings.google.api_key)
         self.model_name = model
-        if not supports(Provider.GOOGLE, self.model_name, Capability.IMAGE_GENERATION):
-            raise ValueError(
-                f"Model '{self.model_name}' does not support IMAGE_GENERATION"
-            )
+        # Non-raising validation; store support state for callers to inspect
+        self.is_supported = supports(
+            Provider.GOOGLE, self.model_name, Capability.IMAGE_GENERATION
+        )
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> List[ImageArtifact]:
         """Generate images using Google's Imagen models."""

--- a/src/celeste_image_generation/providers/huggingface.py
+++ b/src/celeste_image_generation/providers/huggingface.py
@@ -16,18 +16,13 @@ class HuggingFaceImageGenerator(BaseImageGenerator):
     ) -> None:
         super().__init__(**kwargs)
         api_key = settings.huggingface.access_token
-        if not api_key:
-            raise ValueError(
-                "Hugging Face API key not provided. Set HUGGINGFACE_TOKEN."
-            )
+        # Non-raising: proceed with None token; upstream may handle anonymous
         self.model_name = model
         self.client = AsyncInferenceClient(token=api_key)
-        if not supports(
+        # Non-raising validation; store support state for callers to inspect
+        self.is_supported = supports(
             Provider.HUGGINGFACE, self.model_name, Capability.IMAGE_GENERATION
-        ):
-            raise ValueError(
-                f"Model '{self.model_name}' does not support IMAGE_GENERATION"
-            )
+        )
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> List[ImageArtifact]:
         # Produce a single image; callers control multiplicity via parallel calls

--- a/src/celeste_image_generation/providers/local.py
+++ b/src/celeste_image_generation/providers/local.py
@@ -45,10 +45,10 @@ class LocalImageGenerator(BaseImageGenerator):
             self.pipeline.enable_model_cpu_offload()
         else:
             self.pipeline = self.pipeline.to(self.device)
-        if not supports(Provider.LOCAL, self.model_name, Capability.IMAGE_GENERATION):
-            raise ValueError(
-                f"Model '{self.model_name}' does not support IMAGE_GENERATION"
-            )
+        # Non-raising validation; store support state for callers to inspect
+        self.is_supported = supports(
+            Provider.LOCAL, self.model_name, Capability.IMAGE_GENERATION
+        )
 
     async def generate_image(self, prompt: str, **kwargs: Any) -> List[ImageArtifact]:
         # Support common 'n' alias for multiple images


### PR DESCRIPTION
## Summary
- Replace ValueError exceptions with non-raising validation across all image generation providers
- Each provider now stores validation state in an `is_supported` attribute for caller inspection
- API errors return empty lists instead of raising exceptions for graceful degradation

## Changes
- Modified error handling in all provider implementations (Google, HuggingFace, Local, Luma, OpenAI, StabilityAI, XAI)
- Simplified error message in __init__.py for unsupported providers
- Providers continue execution even with missing API keys or unsupported models
- Network/API failures now return empty results rather than throwing exceptions

## Test plan
- [ ] Verify providers initialize without errors even with invalid configurations
- [ ] Test that `is_supported` attribute correctly reflects model capabilities
- [ ] Confirm API failures return empty lists instead of raising exceptions
- [ ] Validate existing functionality remains intact for valid configurations