### PR TITLE
Fix: Improve code formatting in example.py

### DIFF
--- a/example.py
+++ b/example.py
@@ -79,7 +79,7 @@ if st.button("🎨 Generate", type="primary", use_container_width=True):
                     if img.data:
                         target.image(
                             img.data,
-                            caption=f"Image {shown+1}",
+                            caption=f"Image {shown + 1}",
                             use_container_width=True,
                         )
                         with st.expander("Metadata"):


### PR DESCRIPTION
## Summary
- Fixed spacing around operator in caption string concatenation to improve code readability
- Changed `shown+1` to `shown + 1` following PEP 8 style guidelines

## Changes
- Added proper spacing around the `+` operator in the image caption formatting

## Test Plan
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [x] Code formatting follows Python style guidelines
- [ ] Verify Streamlit app still displays image captions correctly